### PR TITLE
add docker compose app-profile

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@ repositories {
 
 configurations {
     // for dependencies that are needed for development only
-    developmentOnly 
+    developmentOnly
 }
 
 dependencies {
@@ -80,16 +80,16 @@ allOpen {
 
 compileKotlin {
 	kotlinOptions {
-	    jvmTarget = '1.8' 
+	    jvmTarget = '1.8'
 	    //Will retain parameter names for Java reflection
-	    javaParameters = true 
+	    javaParameters = true
 	}
 }
 
 compileTestKotlin {
 	kotlinOptions {
-	    jvmTarget = '1.8' 
-	    javaParameters = true 
+	    jvmTarget = '1.8'
+	    javaParameters = true
 	}
 }
 
@@ -101,6 +101,8 @@ tasks.withType(JavaExec) {
     classpath += configurations.developmentOnly
     if(System.getenv('RUN_LOCAL') != null)
         jvmArgs('-noverify', '-XX:TieredStopAtLevel=1', '-Dcom.sun.management.jmxremote', '-Dmicronaut.environments=local')
+    else if (System.getenv('RUN_LOCAL_DOCKER') != null)
+        jvmArgs('-noverify', '-XX:TieredStopAtLevel=1', '-Dcom.sun.management.jmxremote', '-Dmicronaut.environments=local-docker')
     else
         jvmArgs('-noverify', '-XX:TieredStopAtLevel=1', '-Dcom.sun.management.jmxremote')
 }

--- a/src/main/kotlin/no/nav/cv/eures/infrastructure/database/DataSourceFactory.kt
+++ b/src/main/kotlin/no/nav/cv/eures/infrastructure/database/DataSourceFactory.kt
@@ -11,7 +11,7 @@ import javax.annotation.PreDestroy
 
 
 @Factory
-@Requires(notEnv = [ "test", "local" ])
+@Requires(notEnv = [ "test", "local", "local-docker" ])
 @Replaces(factory = DatasourceFactory::class)
 class VaultDatasourceFactory(
         @Value("\${db.vault.path}") private val vaultPath: String,

--- a/src/main/resources/application-local-docker.yml
+++ b/src/main/resources/application-local-docker.yml
@@ -1,0 +1,36 @@
+kafka:
+  bootstrap:
+    servers:
+      - ${KAFKA_HOST:localhost}:9092
+  topics:
+    consumers:
+      cv_endret: "arbeid-pam-cv-endret-v2-dev"
+  health:
+    enabled: false
+  security:
+    protocol:
+  sasl:
+    jaas:
+      config:
+    mechanism:
+  ssl:
+    truststore:
+      location:
+      password:
+  schema.registry.url: http://${KAFKA_HOST:localhost}:8081
+
+datasources:
+  default:
+    connectionTestQuery: "select 1"
+    jdbcUrl: "jdbc:postgresql://localhost:5432/test_db"
+    driverClassName: 'org.postgresql.Driver'
+    username: testuser
+    password: testpassword
+
+flyway:
+  datasources:
+    default:
+      locations: classpath:db
+      initSql:
+        - 'SET ROLE "testuser"'
+


### PR DESCRIPTION
Add new application profile for running app with docker-compose db.

Use ` RUN_LOCAL_DOCKER=true gradle run` to run the app with this profile.

Note: the docker-compose configuration can be found in `pam-cv-api/migrering/test/resources/`