### PR TITLE
Delete Samtykke and XmlCv if Samtykke is more than a year old.

### DIFF
--- a/src/main/kotlin/no/nav/cv/eures/samtykke/SamtykkeRepository.kt
+++ b/src/main/kotlin/no/nav/cv/eures/samtykke/SamtykkeRepository.kt
@@ -14,6 +14,7 @@ interface SamtykkeRepository {
 
     fun hentSamtykke(foedselsnummer: String) : Samtykke?
     fun hentSamtykkeUtenNaaverendeXml(foedselsnummer: List<String>) : List<SamtykkeEntity>
+    fun hentGamleSamtykker(time: ZonedDateTime): List<SamtykkeEntity>
     fun hentAntallSamtykker() : Long
     fun slettSamtykke(foedselsnummer: String) : Int
     fun oppdaterSamtykke(foedselsnummer: String, samtykke: Samtykke)
@@ -61,6 +62,19 @@ private open class JpaSamtykkeRepository(
                 .setParameter("foedselsnummer", foedselsnummer)
                 .resultList
                 .map { it as SamtykkeEntity }
+
+    private val hentGamleSamtykkerQuery =
+        """
+            SELECT * FROM SAMTYKKE
+            WHERE SIST_ENDRET < :olderThan
+        """.replace(serieMedWhitespace, " ")
+
+    @Transactional
+    override fun hentGamleSamtykker(olderThan: ZonedDateTime): List<SamtykkeEntity> =
+        entityManager.createNativeQuery(hentGamleSamtykkerQuery, SamtykkeEntity::class.java)
+            .setParameter("olderThan", olderThan)
+            .resultList
+            .map { it as SamtykkeEntity }
 
     private val hentAntallSamtykker =
             """

--- a/src/test/kotlin/no/nav/cv/eures/scheduled/PruneSamtykkeTest.kt
+++ b/src/test/kotlin/no/nav/cv/eures/scheduled/PruneSamtykkeTest.kt
@@ -1,0 +1,101 @@
+package no.nav.cv.eures.scheduled
+
+import no.nav.cv.eures.cv.CvRepository
+import no.nav.cv.eures.cv.CvXml
+import no.nav.cv.eures.cv.CvXmlRepository
+import no.nav.cv.eures.cv.RawCV
+import no.nav.cv.eures.samtykke.Samtykke
+import no.nav.cv.eures.samtykke.SamtykkeRepository
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.context.ActiveProfiles
+import java.time.ZonedDateTime
+
+@SpringBootTest
+@ActiveProfiles("test")
+internal class PruneSamtykkeTest {
+
+    @Autowired
+    lateinit var samtykkeRepository: SamtykkeRepository
+
+    @Autowired
+    lateinit var cvRepository: CvRepository
+
+    @Autowired
+    lateinit var cvXmlRepository: CvXmlRepository
+
+    @Autowired
+    lateinit var pruneSamtykke: PruneSamtykke
+
+    @Test
+    fun `delete old samtykke`() {
+        val deleteThisFoedselsnummer = "111"
+        val deleteThisSistEndret = ZonedDateTime.now().minusYears(2)
+
+        val keepThisFoedselsnummer = "222"
+        val keepThisSistEndret = ZonedDateTime.now()
+
+        val deleteThisButKeepRawCv = RawCV.create(
+            aktoerId = "aid1",
+            foedselsnummer = deleteThisFoedselsnummer,
+            sistEndret = deleteThisSistEndret,
+            rawAvro = "Raw Avro",
+            meldingstype = RawCV.Companion.RecordType.CREATE)
+
+        val deleteThisXmlCv = CvXml.create(
+            reference = "delete",
+            foedselsnummer = deleteThisFoedselsnummer,
+            opprettet = deleteThisSistEndret,
+            sistEndret = deleteThisSistEndret,
+            slettet = null,
+            xml = "xml string",
+            checksum = "checksum")
+
+        val keepThisButKeepRawCv = RawCV.create(
+            aktoerId = "aid2",
+            foedselsnummer = keepThisFoedselsnummer,
+            sistEndret = keepThisSistEndret,
+            rawAvro = "Raw Avro",
+            meldingstype = RawCV.Companion.RecordType.CREATE)
+
+        val keepThisXmlCv = CvXml.create(
+            reference = "keep",
+            foedselsnummer = keepThisFoedselsnummer,
+            opprettet = keepThisSistEndret,
+            sistEndret = keepThisSistEndret,
+            slettet = null,
+            xml = "xml string",
+            checksum = "checksum")
+
+
+        samtykkeRepository.oppdaterSamtykke(deleteThisFoedselsnummer, Samtykke(deleteThisSistEndret))
+        cvRepository.save(deleteThisButKeepRawCv)
+        cvXmlRepository.save(deleteThisXmlCv)
+
+        samtykkeRepository.oppdaterSamtykke(keepThisFoedselsnummer, Samtykke(keepThisSistEndret))
+        cvRepository.save(keepThisButKeepRawCv)
+        cvXmlRepository.save(keepThisXmlCv)
+
+
+        pruneSamtykke.pruneBasedOnSamtykkeExpiry()
+
+        val deletedSamtykke = samtykkeRepository.hentSamtykke(deleteThisFoedselsnummer)
+        val notDeletedRawCv = cvRepository.hentCvByFoedselsnummer(deleteThisFoedselsnummer)
+        val deletedXmlCv = cvXmlRepository.fetch(deleteThisFoedselsnummer)
+
+        assertNull(deletedSamtykke)
+        assertNotNull(notDeletedRawCv)
+        assertNotNull(deletedXmlCv?.slettet)
+
+        val keptSamtykke = samtykkeRepository.hentSamtykke(keepThisFoedselsnummer)
+        val keptRawCv = cvRepository.hentCvByFoedselsnummer(keepThisFoedselsnummer)
+        val keptXmlCv = cvXmlRepository.fetch(keepThisFoedselsnummer)
+
+        assertNotNull(keptSamtykke)
+        assertNotNull(keptRawCv)
+        assertNull(keptXmlCv?.slettet)
+
+    }
+}


### PR DESCRIPTION
Create function for deleting based on Samtykke age and split PruneSamtykke service into three functions (to facilitate unit testing).

Note: When "deleting" XmlCv (by setting the `slettet` timestamp), we're now also setting the `xml` field itself to a blank string.