### PR TITLE
Legger til støtte for nullverdier i startdato

### DIFF
--- a/src/main/kotlin/no/nav/cv/eures/konverterer/EducationHistoryConverter.kt
+++ b/src/main/kotlin/no/nav/cv/eures/konverterer/EducationHistoryConverter.kt
@@ -25,7 +25,7 @@ class EducationHistoryConverter(
             organizationName = it.laerested,
             programName = "${it.utdanningsretning} - ${it.beskrivelse}",
             attendancePeriod = AttendancePeriod(
-                    it.fraTidspunkt?.toFormattedDateTime(),
+                    it.fraTidspunkt?.toFormattedDateTime() ?: DateText("Unknown"),
                     it.tilTidspunkt?.toFormattedDateTime()),
             educationLevelCode = EducationLevelCode(code = it.nuskodeGrad.toEducationLevelCode()),
             educationDegree = educationDegree(it.nuskodeGrad.toEducationLevelCode())

--- a/src/main/kotlin/no/nav/cv/eures/konverterer/EmploymentHistoryConverter.kt
+++ b/src/main/kotlin/no/nav/cv/eures/konverterer/EmploymentHistoryConverter.kt
@@ -23,7 +23,7 @@ class EmploymentHistoryConverter(
         EmployerHistory(
                 organizationName = it?.arbeidsgiver ?: "",
                 employmentPeriod = AttendancePeriod(
-                        it.fraTidspunkt.toFormattedDateTime(),
+                        it.fraTidspunkt?.toFormattedDateTime() ?: DateText("Unknown"),
                         it.tilTidspunkt?.toFormattedDateTime()
                 ),
                 positionHistory = it.toPositionHistory())
@@ -33,7 +33,7 @@ class EmploymentHistoryConverter(
     fun Arbeidserfaring.toPositionHistory() = listOf(PositionHistory(
             positionTitle = stillingstittel ?: stillingstittelFritekst, // TODO Skal dette være friktekstfeltet?
             employmentPeriod = AttendancePeriod(
-                    fraTidspunkt.toFormattedDateTime(),
+                    fraTidspunkt?.toFormattedDateTime() ?: DateText("Unknown"),
                     tilTidspunkt?.toFormattedDateTime()
             ),
             jobCategoryCode = stillingstittel?.toJobCategoryCode()

--- a/src/main/kotlin/no/nav/cv/eures/konverterer/XmlSerializer.kt
+++ b/src/main/kotlin/no/nav/cv/eures/konverterer/XmlSerializer.kt
@@ -12,7 +12,6 @@ import com.fasterxml.jackson.dataformat.xml.XmlMapper
 import com.fasterxml.jackson.dataformat.xml.ser.ToXmlGenerator
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
 import com.fasterxml.jackson.module.kotlin.registerKotlinModule
-import no.nav.cv.eures.model.Candidate
 
 object XmlSerializer {
     private val stringSerializer = StringSerializer()
@@ -36,5 +35,5 @@ object XmlSerializer {
         })
     }
 
-    fun serialize(candidate:Candidate): String = xml.writeValueAsString(candidate)
+    fun serialize(serializable: Any): String = xml.writeValueAsString(serializable)
 }

--- a/src/main/kotlin/no/nav/cv/eures/model/Common.kt
+++ b/src/main/kotlin/no/nav/cv/eures/model/Common.kt
@@ -2,8 +2,11 @@ package no.nav.cv.eures.model
 
 // 4.13.7.2
 data class AttendancePeriod(
-        val startDate: FormattedDateTime?,
+        val startDate: PeriodStartDate,
         val endDate: FormattedDateTime?
 )
 
-data class FormattedDateTime(val formattedDateTime: String)
+data class FormattedDateTime(val formattedDateTime: String) : PeriodStartDate()
+data class DateText(val dateText: String) : PeriodStartDate()
+
+open class PeriodStartDate

--- a/src/test/kotlin/no/nav/cv/eures/konverterer/EmploymentHistoryConverterTest.kt
+++ b/src/test/kotlin/no/nav/cv/eures/konverterer/EmploymentHistoryConverterTest.kt
@@ -1,0 +1,76 @@
+package no.nav.cv.eures.konverterer
+
+import no.nav.arbeid.cv.avro.Arbeidserfaring
+import no.nav.arbeid.cv.avro.Cv
+import no.nav.cv.eures.janzz.JanzzService
+import no.nav.cv.eures.samtykke.Samtykke
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.context.ActiveProfiles
+import java.time.LocalDate
+
+
+@SpringBootTest
+@ActiveProfiles("test")
+internal class EmploymentHistoryConverterTest {
+
+    @Autowired
+    private lateinit var janzzService: JanzzService
+
+    @Test
+    fun `Arbeidserfaring med startdato null mappes til DateText unknown`() {
+        val arbeidserfaringer = listOf(
+            Arbeidserfaring(null, "Kul kokk med sluttdato", null, null, "NAV-Kantina", LocalDate.now(), null, null, null, true),
+            Arbeidserfaring(null, "Kul kokk uten sluttdato", null, null, "NAV-Kantina", null, null, null, null, true)
+        )
+
+        val cv = Cv()
+        cv.arbeidserfaring = arbeidserfaringer
+        val samtykke = Samtykke(arbeidserfaring = true)
+        val result = EmploymentHistoryConverter(cv, samtykke, janzzService).toXmlRepresentation()
+        val serialisert = XmlSerializer.serialize(result!!)
+
+        assertEquals(expectedXml, serialisert)
+    }
+
+
+    val expectedXml = """<?xml version='1.0' encoding='UTF-8'?>
+<EmploymentHistory>
+  <EmployerHistory>
+    <OrganizationName>NAV-Kantina</OrganizationName>
+    <EmploymentPeriod>
+      <StartDate>
+        <FormattedDateTime>2022-08-26</FormattedDateTime>
+      </StartDate>
+    </EmploymentPeriod>
+    <PositionHistory>
+      <PositionTitle>Kul kokk med sluttdato</PositionTitle>
+      <EmploymentPeriod>
+        <StartDate>
+          <FormattedDateTime>2022-08-26</FormattedDateTime>
+        </StartDate>
+      </EmploymentPeriod>
+    </PositionHistory>
+  </EmployerHistory>
+  <EmployerHistory>
+    <OrganizationName>NAV-Kantina</OrganizationName>
+    <EmploymentPeriod>
+      <StartDate>
+        <DateText>Unknown</DateText>
+      </StartDate>
+    </EmploymentPeriod>
+    <PositionHistory>
+      <PositionTitle>Kul kokk uten sluttdato</PositionTitle>
+      <EmploymentPeriod>
+        <StartDate>
+          <DateText>Unknown</DateText>
+        </StartDate>
+      </EmploymentPeriod>
+    </PositionHistory>
+  </EmployerHistory>
+</EmploymentHistory>
+
+""".trimIndent()
+}


### PR DESCRIPTION
Co-authored-by: Ken Ove Andersen <ken.ove.andersen@nav.no>

Eures støtter to formater på `Start Date`, enten en `Formatted Date Time` med en datoformattert streng, eller `Date Text` som fritekst. 

Fiks er å sende med `Date Text` med verdi `unknown` når vi mangler start dato.

Med startdato:
```
<StartDate>
    <FormattedDateTime>2022-08-26</FormattedDateTime>
 </StartDate>
```

Uten startdato:
```
<StartDate>
    <DateText>Unknown</DateText>
 </StartDate>
```

