### PR TITLE
Bruk janzz typeahead istedenfor labels

### DIFF
--- a/src/main/kotlin/no/nav/cv/eures/janzz/JanzzQuery.kt
+++ b/src/main/kotlin/no/nav/cv/eures/janzz/JanzzQuery.kt
@@ -27,7 +27,7 @@ class JanzzQuery(
         return client.get()
             .uri { uriBuilder ->
                 uriBuilder
-                    .path("/japi/labels/")
+                    .path("/japi/typeahead/")
                     .queryParam("q", query)
                     .queryParam("lang", lang)
                     .queryParam("branch", branch)


### PR DESCRIPTION
Bruker /japi/typeahead istedenfor /japi/labels siden janzz klager på at vi ikke burde bruke labels api'ét...