### PR TITLE
Lagrer ny jsonCv og underOppfoelging når bruker ikke lenger er under oppfølging

### DIFF
--- a/src/main/kotlin/no/nav/cv/eures/cv/CvRawService.kt
+++ b/src/main/kotlin/no/nav/cv/eures/cv/CvRawService.kt
@@ -5,78 +5,68 @@ import no.nav.cv.eures.samtykke.SamtykkeService
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
 import java.time.ZonedDateTime
 
 @Service
-class CvRawService(
-    private val cvRepository: CvRepository,
-    private val samtykkeService: SamtykkeService
-    ) {
-
+class CvRawService(private val cvRepository: CvRepository, private val samtykkeService: SamtykkeService) {
     companion object {
         val log: Logger = LoggerFactory.getLogger(CvRawService::class.java)
     }
 
-    fun createOrUpdateRawCvRecord(dto: CvEndretInternDto, cvAsJson: String) {
-        val foedselsnummer = dto.fodselsnummer
-        val aktoerId = dto.aktorId
+    @Transactional
+    fun updateRawCvRecord(eksisterende: RawCV, dto: CvEndretInternDto, cvAsJson: String) {
+        val erUnderOppfølging = dto.oppfolgingsInformasjon?.erUnderOppfolging ?: false
+        val eksisterendeErUnderOppfølging = eksisterende.underOppfoelging
 
-        if (foedselsnummer == null) {
-            log.warn("Kafkamelding mangler fødselsnummer - hopper over den (${aktoerId}) - Meldingstype: ${dto.meldingstype}.")
+        eksisterende.update(
+            sistEndret = ZonedDateTime.now(),
+            jsonCv = cvAsJson,
+            underOppfoelging = erUnderOppfølging,
+            meldingstype = RawCV.Companion.RecordType.UPDATE
+        )
+
+        try {
+            if (eksisterendeErUnderOppfølging && !erUnderOppfølging) samtykkeService.slettSamtykke(eksisterende.foedselsnummer)
+            cvRepository.saveAndFlush(eksisterende)
+        } catch (e: Exception) {
+            log.error("Fikk exception ${e.message} under oppdatring av cv $this", e)
+        }
+    }
+
+    @Transactional
+    fun createRawCvRecord(dto: CvEndretInternDto, cvAsJson: String) {
+        cvRepository.deleteCvByAktorId(dto.aktorId)
+
+        val newRawCv = RawCV.create(
+            aktoerId = dto.aktorId,
+            foedselsnummer = dto.fodselsnummer!!,
+            sistEndret = ZonedDateTime.now(),
+            jsonCv = cvAsJson,
+            underOppfoelging = dto.oppfolgingsInformasjon?.erUnderOppfolging,
+            meldingstype = RawCV.Companion.RecordType.CREATE
+        )
+
+        try {
+            cvRepository.saveAndFlush(newRawCv)
+        } catch (e: Exception) {
+            log.error("Fikk exception ${e.message} under lagring av cv $this", e)
+        }
+    }
+
+    @Transactional
+    fun createOrUpdateRawCvRecord(dto: CvEndretInternDto, cvAsJson: String) {
+        if (dto.fodselsnummer == null) {
+            log.warn("Kafkamelding mangler fødselsnummer - hopper over den (${dto.aktorId}) - Meldingstype: ${dto.meldingstype}.")
             return
         }
 
-        val existing = cvRepository.hentCvByFoedselsnummer(foedselsnummer)
-
-        if(existing != null) {
-            if (existing.underOppfoelging && (dto.oppfolgingsInformasjon != null && !dto.oppfolgingsInformasjon.erUnderOppfolging)) {
-                log.debug("Deleting ${existing.aktoerId} due to not being 'under oppfølging' anymore")
-
-                // By deleting samtykke we also mark the XML CV for deletion
-                try {
-                    samtykkeService.slettSamtykke(foedselsnummer)
-                } catch (e: Exception) {
-                    log.error("Fikk exception ${e.message} under sletting av cv $this", e)
-                }
-            } else {
-                log.debug("Updating ${existing.aktoerId}")
-                existing.update(
-                    sistEndret = ZonedDateTime.now(),
-                    jsonCv = cvAsJson,
-                    underOppfoelging = (dto.oppfolgingsInformasjon != null),
-                    meldingstype = RawCV.Companion.RecordType.UPDATE
-                )
-
-                try {
-                    cvRepository.saveAndFlush(existing)
-                } catch (e: Exception) {
-                    log.error("Fikk exception ${e.message} under oppdatring av cv $this", e)
-                }
-            }
-        } else {
-            log.debug("inserting new record for $aktoerId")
-
-            cvRepository.deleteCvByAktorId(aktoerId)
-
-            val newRawCv = RawCV.create(
-                aktoerId = aktoerId,
-                foedselsnummer = foedselsnummer,
-                sistEndret = ZonedDateTime.now(),
-                jsonCv = cvAsJson,
-                underOppfoelging = dto.oppfolgingsInformasjon?.erUnderOppfolging,
-                meldingstype = RawCV.Companion.RecordType.CREATE
-            )
-
-            try {
-                cvRepository.saveAndFlush(newRawCv)
-            } catch (e: Exception) {
-                log.error("Fikk exception ${e.message} under lagring av cv $this", e)
-            }
-        }
+        cvRepository.hentCvByFoedselsnummer(dto.fodselsnummer)
+            ?.let { updateRawCvRecord(it, dto, cvAsJson) }
+            ?: createRawCvRecord(dto, cvAsJson)
     }
-    fun deleteCv(aktoerId: String): RawCV? = cvRepository.hentCvByAktoerId(aktoerId)?.update(
-        sistEndret = ZonedDateTime.now(),
-        underOppfoelging = false,
-        meldingstype = RawCV.Companion.RecordType.DELETE
-    )?.let { cvRepository.saveAndFlush(it) }
+
+    fun deleteCv(aktoerId: String): RawCV? = cvRepository.hentCvByAktoerId(aktoerId)
+        ?.update(sistEndret = ZonedDateTime.now(), underOppfoelging = false, meldingstype = RawCV.Companion.RecordType.DELETE)
+        ?.let { cvRepository.saveAndFlush(it) }
 }

--- a/src/main/kotlin/no/nav/cv/eures/samtykke/SamtykkeService.kt
+++ b/src/main/kotlin/no/nav/cv/eures/samtykke/SamtykkeService.kt
@@ -11,7 +11,7 @@ import org.springframework.stereotype.Service
 @Service
 class SamtykkeService(
     private val samtykkeRepository: SamtykkeRepository,
-    private val cvConverterService2: CvConverterService,
+    private val cvConverterService: CvConverterService,
     private val cvRepository: CvRepository,
     private val cvXmlRepository: CvXmlRepository,
     private val meterRegistry: MeterRegistry
@@ -20,8 +20,7 @@ class SamtykkeService(
         val log: Logger = LoggerFactory.getLogger(SamtykkeService::class.java)
     }
 
-    fun hentSamtykke(foedselsnummer: String): Samtykke? =
-            samtykkeRepository.hentSamtykke(foedselsnummer)
+    fun hentSamtykke(foedselsnummer: String): Samtykke? = samtykkeRepository.hentSamtykke(foedselsnummer)
 
     fun slettSamtykke(foedselsnummer: String) {
         val existing = samtykkeRepository.hentSamtykke(foedselsnummer)
@@ -35,7 +34,7 @@ class SamtykkeService(
             log.warn("Got exception when trying to increase metric counter for deleted samtykke", e)
         }
 
-        cvConverterService2.delete(foedselsnummer)
+        cvConverterService.delete(foedselsnummer)
         samtykkeRepository.slettSamtykke(foedselsnummer)
     }
 
@@ -55,7 +54,7 @@ class SamtykkeService(
 
         samtykkeRepository.oppdaterSamtykke(foedselsnummer, samtykke)
                 .run { if (cvRepository.hentCvByFoedselsnummer(foedselsnummer)?.jsonCv != null) {
-                        cvConverterService2.createOrUpdate(foedselsnummer)
+                        cvConverterService.createOrUpdate(foedselsnummer)
                     }
                 }
 

--- a/src/test/kotlin/no/nav/cv/eures/cv/CvRawServiceIntegrationTest.kt
+++ b/src/test/kotlin/no/nav/cv/eures/cv/CvRawServiceIntegrationTest.kt
@@ -1,0 +1,137 @@
+package no.nav.cv.eures.cv
+
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import com.fasterxml.jackson.module.kotlin.readValue
+import no.nav.cv.dto.CvEndretInternDto
+import no.nav.cv.dto.CvMeldingstype
+import no.nav.cv.dto.cv.CvEndretInternCvDto
+import no.nav.cv.dto.cv.CvEndretInternWorkExperience
+import no.nav.cv.dto.oppfolging.CvEndretInternOppfolgingsinformasjonDto
+import no.nav.cv.eures.samtykke.SamtykkeService
+import no.nav.security.token.support.spring.test.EnableMockOAuth2Server
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.`when`
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import java.time.ZonedDateTime
+
+@SpringBootTest
+@EnableMockOAuth2Server
+class CvRawServiceIntegrationTest {
+    lateinit var cvRawService: CvRawService
+
+    @Autowired
+    lateinit var cvRepository: CvRepository
+
+    private val samtykkeService = mock(SamtykkeService::class.java)
+
+    private val objectMapper = jacksonObjectMapper().registerModule(JavaTimeModule())
+
+    @BeforeEach
+    fun init() {
+        cvRawService = CvRawService(cvRepository, samtykkeService)
+    }
+
+    @Test
+    fun `Endringer lagres selv når bruker går fra å ha vært under oppfølging til å ikke være det lenger, men samtykket slettes`() {
+        val aktørId = "1".repeat(13)
+        val fødselsnummer = "1".repeat(11)
+
+        val cv1 = createDto(aktørId, fødselsnummer, emptyList(), createOppfølgingsinformasjon(true), CvMeldingstype.OPPRETT)
+
+        cvRawService.createOrUpdateRawCvRecord(cv1, objectMapper.writeValueAsString(cv1))
+
+        val cv1FraDatabase = cvRepository.hentCvByFoedselsnummer(fødselsnummer)
+        val cv1Dto = objectMapper.readValue<CvEndretInternDto>(cv1FraDatabase?.jsonCv!!)
+
+        assertEquals(0, cv1Dto.cv?.workExperience?.size)
+        assertTrue(cv1FraDatabase.underOppfoelging)
+        assertTrue(cv1Dto.oppfolgingsInformasjon?.erUnderOppfolging ?: false)
+        Mockito.verify(samtykkeService, Mockito.never()).slettSamtykke(fødselsnummer)
+
+        val cv2 = createDto(aktørId, fødselsnummer, listOf(createWorkExperience("Test AS", "Tester")), createOppfølgingsinformasjon(false), CvMeldingstype.ENDRE)
+        cvRawService.createOrUpdateRawCvRecord(cv2, objectMapper.writeValueAsString(cv2))
+
+        val cv2FraDatabase = cvRepository.hentCvByFoedselsnummer(fødselsnummer)
+        val cv2Dto = objectMapper.readValue<CvEndretInternDto>(cv2FraDatabase?.jsonCv!!)
+
+        assertNotEquals(cv1FraDatabase.sistEndret, cv2FraDatabase.sistEndret)
+
+        assertEquals(1, cv2Dto.cv?.workExperience?.size)
+        assertFalse(cv2Dto.oppfolgingsInformasjon?.erUnderOppfolging ?: false)
+        assertFalse(cv2FraDatabase.underOppfoelging)
+        Mockito.verify(samtykkeService, Mockito.times(1)).slettSamtykke(fødselsnummer)
+    }
+
+    private fun createOppfølgingsinformasjon(underOppfølging: Boolean = false) =
+        CvEndretInternOppfolgingsinformasjonDto(
+            formidlingsgruppe = "",
+            fritattKandidatsok = false,
+            hovedmaal = "",
+            manuell = false,
+            oppfolgingskontor = "",
+            servicegruppe = "",
+            veileder = "",
+            tilretteleggingsbehov = false,
+            veilTilretteleggingsbehov = emptyList(),
+            erUnderOppfolging = underOppfølging
+        )
+
+    private fun createWorkExperience(employer: String = "Test AS", jobTitle: String = "Tester") =
+        CvEndretInternWorkExperience(
+            employer = employer,
+            jobTitle = jobTitle,
+            alternativeJobTitle = null,
+            conceptId = null,
+            location = null,
+            description = null,
+            fromDate = null,
+            toDate = null,
+            styrkkode = null,
+            ikkeAktueltForFremtiden = false
+        )
+
+    private fun createDto(
+        aktørId: String,
+        fnr: String,
+        workExperience: List<CvEndretInternWorkExperience> = emptyList(),
+        oppfølgingsinformasjon: CvEndretInternOppfolgingsinformasjonDto? = null,
+        meldingstype: CvMeldingstype = CvMeldingstype.OPPRETT
+    ): CvEndretInternDto {
+        val cv = CvEndretInternCvDto(
+            otherExperience = emptyList(),
+            workExperience = workExperience,
+            courses = emptyList(),
+            certificates = emptyList(),
+            vocationalCertificates = emptyList(),
+            education = emptyList(),
+            driversLicenses = emptyList(),
+            authorizations = emptyList(),
+            languages = emptyList(),
+            skillDrafts = emptyList(),
+            synligForVeileder = false,
+            synligForArbeidsgiver = false,
+            hasCar = true,
+            uuid = null,
+            updatedAt = ZonedDateTime.now(),
+            createdAt = ZonedDateTime.now(),
+            summary = null
+        )
+        return CvEndretInternDto(
+            aktorId = aktørId,
+            meldingstype = meldingstype,
+            cv = cv,
+            fodselsnummer = fnr,
+            jobWishes = null,
+            updatedBy = null,
+            kandidatNr = null,
+            personalia = null,
+            oppfolgingsInformasjon = oppfølgingsinformasjon
+        )
+    }
+}


### PR DESCRIPTION
Har vært en bug hvor brukere som har vært under oppfølging og ikke lenger er det ikke får oppdatert CVen i Eures, og Eures-samtykket slettes ver hver endring av CV, selv ved nytt samtykke.

Dette er fordi vi ikke har oppdatert "underOppfoelging" når oppfølgingen avsluttes, sånn at det alltid ser ut som en bruker går fra å være under oppfølging til å ikke være det, og da sletter vi samtykket og CVen i Eures. 

Siden jsonCv heller ikke oppdateres vil det ved nytt samtykke også dele gammel data, istedet for siste versjon av CVen. 