### PR TITLE
Metrikker via pam-metric-sink

### DIFF
--- a/naiserator.yml
+++ b/naiserator.yml
@@ -73,6 +73,8 @@ spec:
       value: {{ pdl_base_url }}
     - name: SWAGGER_ENABLED
       value: "{{ swagger_enabled }}"
+    - name: KAFKA_PRODUCER_TOPIC_METRIC_SINK
+      value: teampam.metric-sink-v1
   ingresses:
   {{#each ingress as |url|}}
      - {{url}}

--- a/src/main/kotlin/no/nav/cv/eures/cv/KafkaConfig.kt
+++ b/src/main/kotlin/no/nav/cv/eures/cv/KafkaConfig.kt
@@ -2,15 +2,16 @@ package no.nav.cv.eures.cv
 
 import org.apache.kafka.clients.CommonClientConfigs
 import org.apache.kafka.clients.consumer.ConsumerConfig
+import org.apache.kafka.clients.producer.ProducerConfig
 import org.apache.kafka.common.config.SslConfigs
 import org.apache.kafka.common.serialization.StringDeserializer
+import org.apache.kafka.common.serialization.StringSerializer
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.kafka.annotation.EnableKafka
 import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory
-import org.springframework.kafka.core.ConsumerFactory
-import org.springframework.kafka.core.DefaultKafkaConsumerFactory
+import org.springframework.kafka.core.*
 import org.springframework.kafka.listener.CommonContainerStoppingErrorHandler
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor
 import java.time.Duration
@@ -25,7 +26,7 @@ class KafkaConfig {
     lateinit var keyStorePath: String
 
     @Value("\${kafka.aiven.credstorePassword}")
-     private val credstorePassword: String? = null
+    private val credstorePassword: String? = null
 
     @Value("\${kafka.aiven.truststorePath}")
     lateinit var truststorePath: String
@@ -40,8 +41,8 @@ class KafkaConfig {
     fun containerExecutor(): ThreadPoolTaskExecutor = ThreadPoolTaskExecutor().apply { corePoolSize = 10 }
 
     @Bean(name = ["internCvTopicContainerFactory"])
-    fun internCvTopicKafkaListenerConstainerFactory() : ConcurrentKafkaListenerContainerFactory<String, String> {
-        return ConcurrentKafkaListenerContainerFactory<String, String>().apply{
+    fun internCvTopicKafkaListenerConstainerFactory(): ConcurrentKafkaListenerContainerFactory<String, String> {
+        return ConcurrentKafkaListenerContainerFactory<String, String>().apply {
             setConcurrency(1)
             setConsumerFactory(consumerFactoryInternCvTopic())
             containerProperties.pollTimeout = Long.MAX_VALUE
@@ -53,13 +54,37 @@ class KafkaConfig {
     }
 
     @Bean
-    fun consumerFactoryInternCvTopic() : ConsumerFactory<String, String> {
-        val props: MutableMap<String, Any> = mutableMapOf<String, Any>()
+    fun consumerFactoryInternCvTopic(): ConsumerFactory<String, String> {
+        val props = commonSslProps()
         props[ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG] = brokers
         props[ConsumerConfig.GROUP_ID_CONFIG] = groupidInternTopic
-        props[ConsumerConfig.CLIENT_ID_CONFIG] = (System.getenv("POD_NAME") ?: "pam-eures-cv-eksport-${UUID.randomUUID()}")
+        props[ConsumerConfig.CLIENT_ID_CONFIG] =
+            (System.getenv("POD_NAME") ?: "pam-eures-cv-eksport-${UUID.randomUUID()}")
+        props[ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG] = StringDeserializer::class.java.name
+        props[ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG] = StringDeserializer::class.java.name
+        props[ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG] = true
+        props[ConsumerConfig.AUTO_OFFSET_RESET_CONFIG] = "earliest"
 
-        if(!credstorePassword.isNullOrBlank()) {
+        return DefaultKafkaConsumerFactory(props)
+    }
+
+    @Bean
+    fun producerFactory(): ProducerFactory<String, String> {
+        val props = commonSslProps()
+        props[ProducerConfig.BOOTSTRAP_SERVERS_CONFIG] = brokers
+        props[ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG] = StringSerializer::class.java.name
+        props[ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG] = StringSerializer::class.java.name
+        props[ProducerConfig.CLIENT_ID_CONFIG] = "pam-eures-cv-eksport-producer-${UUID.randomUUID()}"
+        return DefaultKafkaProducerFactory(props)
+    }
+
+    @Bean
+    fun kafkaTemplate(): KafkaTemplate<String, String> = KafkaTemplate(producerFactory())
+
+    private fun commonSslProps(): MutableMap<String, Any> {
+        val props: MutableMap<String, Any> = mutableMapOf()
+
+        if (!credstorePassword.isNullOrBlank()) {
             props[SslConfigs.SSL_TRUSTSTORE_PASSWORD_CONFIG] = credstorePassword
             props[SslConfigs.SSL_KEYSTORE_PASSWORD_CONFIG] = credstorePassword
             props[SslConfigs.SSL_KEY_PASSWORD_CONFIG] = credstorePassword
@@ -68,11 +93,6 @@ class KafkaConfig {
             props[SslConfigs.SSL_ENDPOINT_IDENTIFICATION_ALGORITHM_CONFIG] = ""
         }
 
-        props[ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG] = StringDeserializer::class.java.name
-        props[ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG] = StringDeserializer::class.java.name
-        props[ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG] = true
-        props[ConsumerConfig.AUTO_OFFSET_RESET_CONFIG] = "earliest"
-
         System.getenv("KAFKA_KEYSTORE_PATH")?.let {
             props[SslConfigs.SSL_KEYSTORE_LOCATION_CONFIG] = keyStorePath
         }
@@ -80,6 +100,7 @@ class KafkaConfig {
             props[SslConfigs.SSL_TRUSTSTORE_LOCATION_CONFIG] = truststorePath
             props[CommonClientConfigs.SECURITY_PROTOCOL_CONFIG] = "SSL"
         }
-        return DefaultKafkaConsumerFactory<String, String>(props)
+
+        return props
     }
 }

--- a/src/main/kotlin/no/nav/cv/eures/samtykke/SamtykkeRepository.kt
+++ b/src/main/kotlin/no/nav/cv/eures/samtykke/SamtykkeRepository.kt
@@ -15,6 +15,7 @@ interface SamtykkeRepository {
     fun hentSamtykkeUtenNaaverendeXml(foedselsnummer: List<String>) : List<SamtykkeEntity>
     fun hentGamleSamtykker(time: ZonedDateTime): List<SamtykkeEntity>
     fun hentAntallSamtykker() : Long
+    fun hentAntallSamtykkerMedBooleanTrue() : Long
     fun hentAntallSamtykkerPerKategori(): Map<String, Long>
     fun slettSamtykke(foedselsnummer: String) : Int
     fun oppdaterSamtykke(foedselsnummer: String, samtykke: Samtykke)
@@ -85,6 +86,21 @@ private open class JpaSamtykkeRepository(
     @Transactional
     override fun hentAntallSamtykker() : Long
             = (entityManager.createNativeQuery(hentAntallSamtykker)
+            .singleResult as Long)
+
+    private val hentAntallSamtykkerMedBooleanTrue =
+            """
+                SELECT COUNT(*) FROM SAMTYKKE WHERE
+                PERSONALIA = true OR UTDANNING = true OR FAGBREV = true OR
+                ARBEIDSERFARING = true OR ANNEN_ERFARING = true OR FOERERKORT = true OR
+                LOVREGULERTE_YRKER = true OR OFFENTLIGE_GODKJENNINGER = true OR
+                ANDRE_GODKJENNINGER = true OR KURS = true OR SPRAAK = true OR
+                SAMMENDRAG = true OR KOMPETANSER = true OR JOBBOENSKER = true
+            """.replace(serieMedWhitespace, " ")
+
+    @Transactional(readOnly = true)
+    override fun hentAntallSamtykkerMedBooleanTrue(): Long =
+            (entityManager.createNativeQuery(hentAntallSamtykkerMedBooleanTrue)
             .singleResult as Long)
 
 

--- a/src/main/kotlin/no/nav/cv/eures/scheduled/GenerateMetricSinkMetrics.kt
+++ b/src/main/kotlin/no/nav/cv/eures/scheduled/GenerateMetricSinkMetrics.kt
@@ -1,0 +1,76 @@
+package no.nav.cv.eures.scheduled
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.module.kotlin.KotlinModule
+import com.fasterxml.jackson.module.kotlin.readValue
+import no.nav.cv.eures.samtykke.SamtykkeRepository
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.context.annotation.Profile
+import org.springframework.kafka.core.KafkaTemplate
+import org.springframework.scheduling.annotation.Scheduled
+import org.springframework.stereotype.Service
+import java.time.LocalDateTime
+import java.time.format.DateTimeFormatter
+
+data class EuresSamtykkePayload(
+    val antallSamtykker: Long,
+    val antallPerLand: Map<String, Int>,
+)
+
+data class MetricSinkMetrikk(
+    val type: String,
+    val payload: String,
+    val timestamp: String,
+)
+
+@Profile("!test")
+@Service
+class GenerateMetricSinkMetrics(
+    private val samtykkeRepository: SamtykkeRepository,
+    private val kafkaTemplate: KafkaTemplate<String, String>,
+    @Value("\${kafka.topics.producers.metric_sink}") private val metricSinkTopic: String,
+) {
+    companion object {
+        val log: Logger = LoggerFactory.getLogger(GenerateMetricSinkMetrics::class.java)
+    }
+
+    private val objectMapper = ObjectMapper().registerModule(KotlinModule.Builder().build())
+
+    @Scheduled(cron = "0 0 4 * * *")
+    fun generateAndSendMetrics() {
+        try {
+            val count = samtykkeRepository.hentAntallSamtykkerMedBooleanTrue()
+
+            val countryCounts = samtykkeRepository
+                .hentAlleLand().flatMap { json -> objectMapper.readValue<List<String>>(json) }
+                .groupingBy { it }
+                .eachCount()
+
+            val payload = EuresSamtykkePayload(
+                antallSamtykker = count,
+                antallPerLand = countryCounts,
+            )
+
+            val metrikk = MetricSinkMetrikk(
+                type = "EURES_SAMTYKKE",
+                payload = objectMapper.writeValueAsString(payload),
+                timestamp = LocalDateTime.now().withNano(0).format(DateTimeFormatter.ISO_LOCAL_DATE_TIME),
+            )
+
+            log.info("Sending metric-sink metric: $count samtykker, country counts $countryCounts")
+
+            kafkaTemplate.send(metricSinkTopic, objectMapper.writeValueAsString(metrikk))
+                .whenComplete { result, ex ->
+                    if (ex != null) {
+                        log.error("Failed to send EURES_SAMTYKKE metric to metric-sink", ex)
+                    } else {
+                        log.info("Sent EURES_SAMTYKKE metric to metric-sink (offset=${result.recordMetadata.offset()})")
+                    }
+                }
+        } catch (e: Exception) {
+            log.error("Error while generating metrics for metric-sink", e)
+        }
+    }
+}

--- a/src/main/kotlin/no/nav/cv/eures/scheduled/GenerateMetricSinkMetrics.kt
+++ b/src/main/kotlin/no/nav/cv/eures/scheduled/GenerateMetricSinkMetrics.kt
@@ -13,8 +13,9 @@ import org.springframework.scheduling.annotation.Scheduled
 import org.springframework.stereotype.Service
 import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
+import java.util.UUID
 
-data class EuresSamtykkePayload(
+data class EuresCvEksportMetrikkPayload(
     val antallSamtykker: Long,
     val antallPerLand: Map<String, Int>,
 )
@@ -34,6 +35,7 @@ class GenerateMetricSinkMetrics(
 ) {
     companion object {
         val log: Logger = LoggerFactory.getLogger(GenerateMetricSinkMetrics::class.java)
+        val metrikkType = "EURES_CV_EKSPORT"
     }
 
     private val objectMapper = ObjectMapper().registerModule(KotlinModule.Builder().build())
@@ -48,25 +50,25 @@ class GenerateMetricSinkMetrics(
                 .groupingBy { it }
                 .eachCount()
 
-            val payload = EuresSamtykkePayload(
+            val payload = EuresCvEksportMetrikkPayload(
                 antallSamtykker = count,
                 antallPerLand = countryCounts,
             )
 
             val metrikk = MetricSinkMetrikk(
-                type = "EURES_SAMTYKKE",
+                type = metrikkType,
                 payload = objectMapper.writeValueAsString(payload),
                 timestamp = LocalDateTime.now().withNano(0).format(DateTimeFormatter.ISO_LOCAL_DATE_TIME),
             )
 
             log.info("Sending metric-sink metric: $count samtykker, country counts $countryCounts")
 
-            kafkaTemplate.send(metricSinkTopic, objectMapper.writeValueAsString(metrikk))
+            kafkaTemplate.send(metricSinkTopic, UUID.randomUUID().toString(), objectMapper.writeValueAsString(metrikk))
                 .whenComplete { result, ex ->
                     if (ex != null) {
-                        log.error("Failed to send EURES_SAMTYKKE metric to metric-sink", ex)
+                        log.error("Failed to send EURES_CV_EKSPORT metric to metric-sink", ex)
                     } else {
-                        log.info("Sent EURES_SAMTYKKE metric to metric-sink (offset=${result.recordMetadata.offset()})")
+                        log.info("Sent EURES_CV_EKSPORT metric to metric-sink (offset=${result.recordMetadata.offset()})")
                     }
                 }
         } catch (e: Exception) {

--- a/src/main/kotlin/no/nav/cv/eures/scheduled/GenerateMetricSinkMetrics.kt
+++ b/src/main/kotlin/no/nav/cv/eures/scheduled/GenerateMetricSinkMetrics.kt
@@ -40,7 +40,7 @@ class GenerateMetricSinkMetrics(
 
     private val objectMapper = ObjectMapper().registerModule(KotlinModule.Builder().build())
 
-    @Scheduled(cron = "0 */15 * * * *")
+    @Scheduled(cron = "0 0 4 * * *")
     fun generateAndSendMetrics() {
         try {
             val count = samtykkeRepository.hentAntallSamtykkerMedBooleanTrue()

--- a/src/main/kotlin/no/nav/cv/eures/scheduled/GenerateMetricSinkMetrics.kt
+++ b/src/main/kotlin/no/nav/cv/eures/scheduled/GenerateMetricSinkMetrics.kt
@@ -38,7 +38,7 @@ class GenerateMetricSinkMetrics(
 
     private val objectMapper = ObjectMapper().registerModule(KotlinModule.Builder().build())
 
-    @Scheduled(cron = "0 0 4 * * *")
+    @Scheduled(cron = "0 */15 * * * *")
     fun generateAndSendMetrics() {
         try {
             val count = samtykkeRepository.hentAntallSamtykkerMedBooleanTrue()

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -58,6 +58,8 @@ kafka:
   topics:
     consumers:
       cv_endret_intern: ${KAFKA_CONSUMER_TOPIC_CV_ENDRET_INTERN:teampam.cv-endret-intern-v3}
+    producers:
+      metric_sink: ${KAFKA_PRODUCER_TOPIC_METRIC_SINK:teampam.metric-sink-v1}
 
 jackson:
   serializationInclusion: ALWAYS

--- a/src/test/kotlin/no/nav/cv/eures/samtykke/SamtykkeRepositoryTest.kt
+++ b/src/test/kotlin/no/nav/cv/eures/samtykke/SamtykkeRepositoryTest.kt
@@ -79,4 +79,44 @@ internal class SamtykkeRepositoryTest {
         assertEquals(samtykke.offentligeGodkjenninger, hentet?.offentligeGodkjenninger)
 
     }
+
+    @Test
+    fun `hentAntallSamtykkerMedBooleanTrue - teller kun samtykker med minst ett boolean-felt satt til true`() {
+        val medTrue = Samtykke(now, personalia = true)
+        val medFlerTrue = Samtykke(now, utdanning = true, spraak = true)
+        val utenTrue = Samtykke(now)
+
+        samtykkeRepository.oppdaterSamtykke("fnr1", medTrue)
+        samtykkeRepository.oppdaterSamtykke("fnr2", medFlerTrue)
+        samtykkeRepository.oppdaterSamtykke("fnr3", utenTrue)
+
+        val antall = samtykkeRepository.hentAntallSamtykkerMedBooleanTrue()
+
+        assertEquals(2L, antall)
+    }
+
+    @Test
+    fun `hentAntallSamtykkerMedBooleanTrue - returnerer 0 når ingen har boolean true`() {
+        samtykkeRepository.oppdaterSamtykke("fnr1", Samtykke(now))
+        samtykkeRepository.oppdaterSamtykke("fnr2", Samtykke(now))
+
+        assertEquals(0L, samtykkeRepository.hentAntallSamtykkerMedBooleanTrue())
+    }
+
+    @Test
+    fun `hentAntallSamtykkerMedBooleanTrue - teller alle boolean-felter`() {
+        samtykkeRepository.oppdaterSamtykke("fnr1", Samtykke(now, fagbrev = true))
+        samtykkeRepository.oppdaterSamtykke("fnr2", Samtykke(now, arbeidserfaring = true))
+        samtykkeRepository.oppdaterSamtykke("fnr3", Samtykke(now, annenErfaring = true))
+        samtykkeRepository.oppdaterSamtykke("fnr4", Samtykke(now, foererkort = true))
+        samtykkeRepository.oppdaterSamtykke("fnr5", Samtykke(now, lovregulerteYrker = true))
+        samtykkeRepository.oppdaterSamtykke("fnr6", Samtykke(now, offentligeGodkjenninger = true))
+        samtykkeRepository.oppdaterSamtykke("fnr7", Samtykke(now, andreGodkjenninger = true))
+        samtykkeRepository.oppdaterSamtykke("fnr8", Samtykke(now, kurs = true))
+        samtykkeRepository.oppdaterSamtykke("fnr9", Samtykke(now, sammendrag = true))
+        samtykkeRepository.oppdaterSamtykke("fnr10", Samtykke(now, kompetanser = true))
+        samtykkeRepository.oppdaterSamtykke("fnr11", Samtykke(now, jobboensker = true))
+
+        assertEquals(11L, samtykkeRepository.hentAntallSamtykkerMedBooleanTrue())
+    }
 }

--- a/src/test/kotlin/no/nav/cv/eures/samtykke/SamtykkeRepositoryTest.kt
+++ b/src/test/kotlin/no/nav/cv/eures/samtykke/SamtykkeRepositoryTest.kt
@@ -105,18 +105,21 @@ internal class SamtykkeRepositoryTest {
 
     @Test
     fun `hentAntallSamtykkerMedBooleanTrue - teller alle boolean-felter`() {
-        samtykkeRepository.oppdaterSamtykke("fnr1", Samtykke(now, fagbrev = true))
-        samtykkeRepository.oppdaterSamtykke("fnr2", Samtykke(now, arbeidserfaring = true))
-        samtykkeRepository.oppdaterSamtykke("fnr3", Samtykke(now, annenErfaring = true))
-        samtykkeRepository.oppdaterSamtykke("fnr4", Samtykke(now, foererkort = true))
-        samtykkeRepository.oppdaterSamtykke("fnr5", Samtykke(now, lovregulerteYrker = true))
-        samtykkeRepository.oppdaterSamtykke("fnr6", Samtykke(now, offentligeGodkjenninger = true))
-        samtykkeRepository.oppdaterSamtykke("fnr7", Samtykke(now, andreGodkjenninger = true))
-        samtykkeRepository.oppdaterSamtykke("fnr8", Samtykke(now, kurs = true))
-        samtykkeRepository.oppdaterSamtykke("fnr9", Samtykke(now, sammendrag = true))
-        samtykkeRepository.oppdaterSamtykke("fnr10", Samtykke(now, kompetanser = true))
-        samtykkeRepository.oppdaterSamtykke("fnr11", Samtykke(now, jobboensker = true))
+        samtykkeRepository.oppdaterSamtykke("fnr1", Samtykke(now, personalia = true))
+        samtykkeRepository.oppdaterSamtykke("fnr2", Samtykke(now, jobboensker = true))
+        samtykkeRepository.oppdaterSamtykke("fnr3", Samtykke(now, utdanning = true))
+        samtykkeRepository.oppdaterSamtykke("fnr4", Samtykke(now, fagbrev = true))
+        samtykkeRepository.oppdaterSamtykke("fnr5", Samtykke(now, arbeidserfaring = true))
+        samtykkeRepository.oppdaterSamtykke("fnr6", Samtykke(now, annenErfaring = true))
+        samtykkeRepository.oppdaterSamtykke("fnr7", Samtykke(now, foererkort = true))
+        samtykkeRepository.oppdaterSamtykke("fnr8", Samtykke(now, lovregulerteYrker = true))
+        samtykkeRepository.oppdaterSamtykke("fnr9", Samtykke(now, offentligeGodkjenninger = true))
+        samtykkeRepository.oppdaterSamtykke("fnr10", Samtykke(now, andreGodkjenninger = true))
+        samtykkeRepository.oppdaterSamtykke("fnr11", Samtykke(now, kurs = true))
+        samtykkeRepository.oppdaterSamtykke("fnr12", Samtykke(now, spraak = true))
+        samtykkeRepository.oppdaterSamtykke("fnr13", Samtykke(now, sammendrag = true))
+        samtykkeRepository.oppdaterSamtykke("fnr14", Samtykke(now, kompetanser = true))
 
-        assertEquals(11L, samtykkeRepository.hentAntallSamtykkerMedBooleanTrue())
+        assertEquals(14L, samtykkeRepository.hentAntallSamtykkerMedBooleanTrue())
     }
 }

--- a/src/test/kotlin/no/nav/cv/eures/scheduled/GenerateMetricSinkMetricsTest.kt
+++ b/src/test/kotlin/no/nav/cv/eures/scheduled/GenerateMetricSinkMetricsTest.kt
@@ -1,0 +1,121 @@
+package no.nav.cv.eures.scheduled
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.module.kotlin.KotlinModule
+import com.fasterxml.jackson.module.kotlin.readValue
+import no.nav.cv.eures.samtykke.SamtykkeRepository
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito.*
+import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.whenever
+import org.springframework.kafka.core.KafkaTemplate
+
+import java.util.concurrent.CompletableFuture
+
+class GenerateMetricSinkMetricsTest {
+
+    private val samtykkeRepository = mock(SamtykkeRepository::class.java)
+
+    @Suppress("UNCHECKED_CAST")
+    private val kafkaTemplate = mock(KafkaTemplate::class.java) as KafkaTemplate<String, String>
+
+    private val objectMapper = ObjectMapper().registerModule(KotlinModule.Builder().build())
+
+    private lateinit var generateMetricSinkMetrics: GenerateMetricSinkMetrics
+
+    private val topic = "teampam.metric-sink-v1"
+
+    @BeforeEach
+    fun setup() {
+        generateMetricSinkMetrics = GenerateMetricSinkMetrics(
+                samtykkeRepository,
+                kafkaTemplate,
+                topic,
+        )
+    }
+
+    @Test
+    fun `should send single kafka message with samtykke count and country counts`() {
+        whenever(samtykkeRepository.hentAntallSamtykkerMedBooleanTrue()).thenReturn(42L)
+        whenever(samtykkeRepository.hentAlleLand()).thenReturn(listOf(
+                """["NO","SE"]""",
+                """["NO","DE"]""",
+                """["NO"]""",
+        ))
+
+        val valueCaptor = argumentCaptor<String>()
+        whenever(kafkaTemplate.send(eq(topic), valueCaptor.capture()))
+                .thenReturn(CompletableFuture())
+
+        generateMetricSinkMetrics.generateAndSendMetrics()
+
+        verify(kafkaTemplate, times(1)).send(eq(topic), any())
+
+        val sentJson = valueCaptor.firstValue
+        val metrikk = objectMapper.readValue<MetricSinkMetrikk>(sentJson)
+
+        assertEquals("EURES_SAMTYKKE", metrikk.type)
+        assertNotNull(metrikk.timestamp)
+        assertFalse(metrikk.timestamp.contains("Z"), "Timestamp should be LocalDateTime format without timezone")
+
+        val payload = objectMapper.readValue<EuresSamtykkePayload>(metrikk.payload)
+        assertEquals(42L, payload.antallSamtykker)
+        assertEquals(3, payload.antallPerLand["NO"])
+        assertEquals(1, payload.antallPerLand["SE"])
+        assertEquals(1, payload.antallPerLand["DE"])
+    }
+
+    @Test
+    fun `should handle empty land list`() {
+        whenever(samtykkeRepository.hentAntallSamtykkerMedBooleanTrue()).thenReturn(0L)
+        whenever(samtykkeRepository.hentAlleLand()).thenReturn(emptyList())
+
+        val valueCaptor = argumentCaptor<String>()
+        whenever(kafkaTemplate.send(eq(topic), valueCaptor.capture()))
+                .thenReturn(CompletableFuture())
+
+        generateMetricSinkMetrics.generateAndSendMetrics()
+
+        verify(kafkaTemplate, times(1)).send(eq(topic), any())
+
+        val metrikk = objectMapper.readValue<MetricSinkMetrikk>(valueCaptor.firstValue)
+        val payload = objectMapper.readValue<EuresSamtykkePayload>(metrikk.payload)
+
+        assertEquals(0L, payload.antallSamtykker)
+        assertTrue(payload.antallPerLand.isEmpty())
+    }
+
+    @Test
+    fun `should not propagate exceptions from repository`() {
+        whenever(samtykkeRepository.hentAntallSamtykkerMedBooleanTrue())
+                .thenThrow(RuntimeException("DB error"))
+
+        assertDoesNotThrow { generateMetricSinkMetrics.generateAndSendMetrics() }
+        verify(kafkaTemplate, never()).send(any<String>(), any())
+    }
+
+    @Test
+    fun `payload should be valid json string inside metrikk`() {
+        whenever(samtykkeRepository.hentAntallSamtykkerMedBooleanTrue()).thenReturn(5L)
+        whenever(samtykkeRepository.hentAlleLand()).thenReturn(listOf("""["FI"]"""))
+
+        val valueCaptor = argumentCaptor<String>()
+        whenever(kafkaTemplate.send(eq(topic), valueCaptor.capture()))
+                .thenReturn(CompletableFuture())
+
+        generateMetricSinkMetrics.generateAndSendMetrics()
+
+        val outerMap = objectMapper.readValue<Map<String, Any>>(valueCaptor.firstValue)
+        assertEquals("EURES_SAMTYKKE", outerMap["type"])
+
+        // payload field should be a string (not nested object) per pam-metric-sink contract
+        assertTrue(outerMap["payload"] is String, "payload should be a JSON string, not a nested object")
+
+        // that string should itself be valid JSON
+        val payloadMap = objectMapper.readValue<Map<String, Any>>(outerMap["payload"] as String)
+        assertEquals(5, payloadMap["antallSamtykker"])
+        assertEquals(mapOf("FI" to 1), payloadMap["antallPerLand"])
+    }
+}

--- a/src/test/kotlin/no/nav/cv/eures/scheduled/GenerateMetricSinkMetricsTest.kt
+++ b/src/test/kotlin/no/nav/cv/eures/scheduled/GenerateMetricSinkMetricsTest.kt
@@ -46,21 +46,21 @@ class GenerateMetricSinkMetricsTest {
         ))
 
         val valueCaptor = argumentCaptor<String>()
-        whenever(kafkaTemplate.send(eq(topic), valueCaptor.capture()))
+        whenever(kafkaTemplate.send(eq(topic), any(), valueCaptor.capture()))
                 .thenReturn(CompletableFuture())
 
         generateMetricSinkMetrics.generateAndSendMetrics()
 
-        verify(kafkaTemplate, times(1)).send(eq(topic), any())
+        verify(kafkaTemplate, times(1)).send(eq(topic), any(), any())
 
         val sentJson = valueCaptor.firstValue
         val metrikk = objectMapper.readValue<MetricSinkMetrikk>(sentJson)
 
-        assertEquals("EURES_SAMTYKKE", metrikk.type)
+        assertEquals("EURES_CV_EKSPORT", metrikk.type)
         assertNotNull(metrikk.timestamp)
         assertFalse(metrikk.timestamp.contains("Z"), "Timestamp should be LocalDateTime format without timezone")
 
-        val payload = objectMapper.readValue<EuresSamtykkePayload>(metrikk.payload)
+        val payload = objectMapper.readValue<EuresCvEksportMetrikkPayload>(metrikk.payload)
         assertEquals(42L, payload.antallSamtykker)
         assertEquals(3, payload.antallPerLand["NO"])
         assertEquals(1, payload.antallPerLand["SE"])
@@ -73,15 +73,15 @@ class GenerateMetricSinkMetricsTest {
         whenever(samtykkeRepository.hentAlleLand()).thenReturn(emptyList())
 
         val valueCaptor = argumentCaptor<String>()
-        whenever(kafkaTemplate.send(eq(topic), valueCaptor.capture()))
+        whenever(kafkaTemplate.send(eq(topic), any(), valueCaptor.capture()))
                 .thenReturn(CompletableFuture())
 
         generateMetricSinkMetrics.generateAndSendMetrics()
 
-        verify(kafkaTemplate, times(1)).send(eq(topic), any())
+        verify(kafkaTemplate, times(1)).send(eq(topic), any(), any())
 
         val metrikk = objectMapper.readValue<MetricSinkMetrikk>(valueCaptor.firstValue)
-        val payload = objectMapper.readValue<EuresSamtykkePayload>(metrikk.payload)
+        val payload = objectMapper.readValue<EuresCvEksportMetrikkPayload>(metrikk.payload)
 
         assertEquals(0L, payload.antallSamtykker)
         assertTrue(payload.antallPerLand.isEmpty())
@@ -93,7 +93,7 @@ class GenerateMetricSinkMetricsTest {
                 .thenThrow(RuntimeException("DB error"))
 
         assertDoesNotThrow { generateMetricSinkMetrics.generateAndSendMetrics() }
-        verify(kafkaTemplate, never()).send(any<String>(), any())
+        verify(kafkaTemplate, never()).send(any(), any(), any())
     }
 
     @Test
@@ -102,13 +102,13 @@ class GenerateMetricSinkMetricsTest {
         whenever(samtykkeRepository.hentAlleLand()).thenReturn(listOf("""["FI"]"""))
 
         val valueCaptor = argumentCaptor<String>()
-        whenever(kafkaTemplate.send(eq(topic), valueCaptor.capture()))
+        whenever(kafkaTemplate.send(eq(topic), any(), valueCaptor.capture()))
                 .thenReturn(CompletableFuture())
 
         generateMetricSinkMetrics.generateAndSendMetrics()
 
         val outerMap = objectMapper.readValue<Map<String, Any>>(valueCaptor.firstValue)
-        assertEquals("EURES_SAMTYKKE", outerMap["type"])
+        assertEquals("EURES_CV_EKSPORT", outerMap["type"])
 
         // payload field should be a string (not nested object) per pam-metric-sink contract
         assertTrue(outerMap["payload"] is String, "payload should be a JSON string, not a nested object")


### PR DESCRIPTION
Datastoryen vi leverer ut baserer seg per i dag på metrikker som sendes til og leses fra prometheus i en litt for komplisert løype. Det vil ikke være tilgjengelig fremover, muligens etter sommeren.

Legger opp for at vi bare sender metrikker via pam-metric-sink og lager et metabase-dashboard med de viktigste tingene fremover. 