### PR TITLE
Fjern CPU-limit

### DIFF
--- a/naiserator.yml
+++ b/naiserator.yml
@@ -20,7 +20,6 @@ spec:
     cpuThresholdPercentage: 50
   resources:
     limits:
-      cpu: 1000m
       memory: 2048Mi
     requests:
       cpu: 200m


### PR DESCRIPTION
Fjerner `spec.resources.limits.cpu` fra nais-konfigen, i tråd med anbefalt praksis for nais-applikasjoner.

Se [Nais good practices](https://docs.nais.io/workloads/explanations/good-practices/index.html#set-reasonable-resource-requests-and-limits).